### PR TITLE
Use port 0 that maps to random port in http

### DIFF
--- a/card-wallet-http-adapter/src/test/kotlin/org/example/demo/CardWalletHttpTest.kt
+++ b/card-wallet-http-adapter/src/test/kotlin/org/example/demo/CardWalletHttpTest.kt
@@ -11,7 +11,7 @@ class CardWalletHttpTest: CardWalletContract() {
 
     private val httpServer: Http4kServer = CardWalletWebController(InMemoryCardWallet())
         .withFilter(ServerFilters.CatchLensFailure())
-        .asServer(SunHttp())
+        .asServer(SunHttp(0)) // 0 port means assigning to random port
 
     override val cardWallet: CardWalletPort =
         CardWalletHttpClientFactory.ofUri("http://localhost:${httpServer.port()}")


### PR DESCRIPTION
Tests in parallel can lead to port already used.