### PR TITLE
Rename logic dependency abstraction

### DIFF
--- a/card-wallet-application/src/main/kotlin/org/example/demo/CardWalletApplication.kt
+++ b/card-wallet-application/src/main/kotlin/org/example/demo/CardWalletApplication.kt
@@ -10,7 +10,7 @@ import org.koin.dsl.module
 val module = module {
     single<MongoDbProperties> { MongoDbConfig(port = getProperty("mongo_db_port").toInt()) }
     single { createCardWalletNoSqlRepository(get()) }
-    single<CardWalletPort> { CardWalletLogic(repo = get()) }
+    single<CardWalletPort> { CardWalletLogic(storage = get()) }
     single { CardWalletHttpServer(get()) }
 }
 

--- a/card-wallet-domain/src/main/kotlin/org/example/demo/port.kt
+++ b/card-wallet-domain/src/main/kotlin/org/example/demo/port.kt
@@ -17,7 +17,7 @@ interface CardWalletPort {
 /**
  * Secondary/driven/output port that shapes how domain stores the state.
  */
-interface CardWalletRepositoryPort {
+interface CardWalletStoragePort {
     fun save(wallet: Wallet): Wallet
     fun getAll(): List<Wallet>
     fun getWalletById(id: UUID): Wallet

--- a/card-wallet-domain/src/test/kotlin/org/example/demo/CardWalletLogicTest.kt
+++ b/card-wallet-domain/src/test/kotlin/org/example/demo/CardWalletLogicTest.kt
@@ -13,7 +13,7 @@ class CardWalletLogicTest: CardWalletContract() {
 
     init {
         walletId = UUID.fromString("ded99ee0-d211-4d9e-a5c1-d69a98fc2040")
-        cardWallet = CardWalletLogic({ walletId }, FakeCardWalletRepository())
+        cardWallet = CardWalletLogic({ walletId }, FakeCardWalletStorage())
     }
 
     @Test

--- a/card-wallet-domain/src/test/kotlin/org/example/demo/InMemoryCardWalletRepositoryTest.kt
+++ b/card-wallet-domain/src/test/kotlin/org/example/demo/InMemoryCardWalletRepositoryTest.kt
@@ -6,7 +6,7 @@ import java.util.*
 
 class InMemoryCardWalletRepositoryTest: CardWalletRepositoryContract() {
 
-    override val cardWalletRepo: CardWalletRepositoryPort = FakeCardWalletRepository()
+    override val cardWalletRepo: CardWalletStoragePort = FakeCardWalletStorage()
 
     @Test
     fun `cannot save wallet that already exists`() {

--- a/card-wallet-domain/src/testFixtures/kotlin/org/example/demo/CardWalletRepositoryContract.kt
+++ b/card-wallet-domain/src/testFixtures/kotlin/org/example/demo/CardWalletRepositoryContract.kt
@@ -7,7 +7,7 @@ import java.util.*
 
 abstract class CardWalletRepositoryContract {
 
-    abstract val cardWalletRepo: CardWalletRepositoryPort
+    abstract val cardWalletRepo: CardWalletStoragePort
 
     @Test
     fun `can persist wallets`() {

--- a/card-wallet-domain/src/testFixtures/kotlin/org/example/demo/FakeCardWalletStorage.kt
+++ b/card-wallet-domain/src/testFixtures/kotlin/org/example/demo/FakeCardWalletStorage.kt
@@ -2,7 +2,7 @@ package org.example.demo
 
 import java.util.*
 
-class FakeCardWalletRepository: CardWalletRepositoryPort {
+class FakeCardWalletStorage: CardWalletStoragePort {
 
     private val wallets = mutableMapOf<UUID, Wallet>()
 

--- a/card-wallet-domain/src/testFixtures/kotlin/org/example/demo/InMemoryCardWallet.kt
+++ b/card-wallet-domain/src/testFixtures/kotlin/org/example/demo/InMemoryCardWallet.kt
@@ -4,5 +4,5 @@ package org.example.demo
  * Use this to refer to domain implementation with in-memory database, easy for testing.
  */
 object InMemoryCardWallet {
-    operator fun invoke(): CardWalletPort = CardWalletLogic(repo = FakeCardWalletRepository())
+    operator fun invoke(): CardWalletPort = CardWalletLogic(storage = FakeCardWalletStorage())
 }

--- a/card-wallet-nosql-adapter/src/main/kotlin/org/example/demo/CardWalletNoSqlStorage.kt
+++ b/card-wallet-nosql-adapter/src/main/kotlin/org/example/demo/CardWalletNoSqlStorage.kt
@@ -7,11 +7,11 @@ import org.litote.kmongo.getCollection
 import org.litote.kmongo.updateOne
 import java.util.*
 
-fun createCardWalletNoSqlRepository(mongoConfig: MongoDbProperties): CardWalletRepositoryPort {
-    return CardWalletNoSqlRepository(createMongoDbClient(mongoConfig))
+fun createCardWalletNoSqlRepository(mongoConfig: MongoDbProperties): CardWalletStoragePort {
+    return CardWalletNoSqlStorage(createMongoDbClient(mongoConfig))
 }
 
-class CardWalletNoSqlRepository internal constructor(mongoClient: MongoClient): CardWalletRepositoryPort {
+class CardWalletNoSqlStorage internal constructor(mongoClient: MongoClient): CardWalletStoragePort {
 
     private val walletsCol: MongoCollection<Wallet> =
         mongoClient.getDatabase(MongoDbConfig.CARD_WALLET_DB_NAME).getCollection<Wallet>(MongoDbConfig.WALLETS_COLLECTION_NAME)

--- a/card-wallet-nosql-adapter/src/test/kotlin/org/example/demo/CardWalletNoSqlRepositoryTest.kt
+++ b/card-wallet-nosql-adapter/src/test/kotlin/org/example/demo/CardWalletNoSqlRepositoryTest.kt
@@ -20,7 +20,7 @@ class CardWalletNoSqlRepositoryTest: CardWalletRepositoryContract() {
         override fun getUrl(): String = "mongodb://localhost:${mongoDb.port}"
     }
 
-    override val cardWalletRepo: CardWalletRepositoryPort = createCardWalletNoSqlRepository(mongoConfig)
+    override val cardWalletRepo: CardWalletStoragePort = createCardWalletNoSqlRepository(mongoConfig)
 
     @AfterEach
     fun clean() {


### PR DESCRIPTION
The repository pattern is used for collecting domain types and creating
an aggregate. It does not concern write/read data in storage system.